### PR TITLE
Template context parameter to callbacks

### DIFF
--- a/src/BackgroundPublish.h
+++ b/src/BackgroundPublish.h
@@ -326,11 +326,13 @@ bool BackgroundPublish<NumQueues>::publish(const char *name,
 {
     if (!running) {
         logger.error("publisher not initialized");
+        cb(particle::Error::INVALID_STATE, name, data);
         return false;
     }
 
     if (priority >= NumQueues) {
         logger.error("priority %d exceeds number of queues %d", priority, NumQueues);
+        cb(particle::Error::INVALID_ARGUMENT, name, data);
         return false;
     }
 
@@ -338,6 +340,7 @@ bool BackgroundPublish<NumQueues>::publish(const char *name,
 
     if(_queues[priority].size() >= maxEntries) {
         logger.error("queue at priority %d is full", priority);
+        cb(particle::Error::BUSY, name, data);
         return false;
     }
     _queues[priority].emplace();

--- a/test/Particle.h
+++ b/test/Particle.h
@@ -179,6 +179,9 @@ public:
     enum Type {
         NONE = 0,
         UNKNOWN,
+        INVALID_STATE,
+        INVALID_ARGUMENT,
+        BUSY,
         LIMIT_EXCEEDED,
         CANCELLED,
     };

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -11,16 +11,30 @@ particle::Error status_returned;
 
 void priority_high_cb(particle::Error status,
     const char *event_name,
-    const char *event_data,
-    const void *event_context) {
+    const char *event_data) {
     status_returned = status;
     high_cb_counter++;
 }
 
 void priority_low_cb(particle::Error status,
     const char *event_name,
+    const char *event_data) {
+    status_returned = status;
+    low_cb_counter++;
+}
+
+void priority_high_cb2(particle::Error status,
+    const char *event_name,
     const char *event_data,
-    const void *event_context) {
+    const int context) {
+    status_returned = status;
+    high_cb_counter++;
+}
+
+void priority_low_cb2(particle::Error status,
+    const char *event_name,
+    const char *event_data,
+    const int context) {
     status_returned = status;
     low_cb_counter++;
 }
@@ -61,17 +75,17 @@ TEST_CASE("Test Background Publish") {
     publisher.start();
 
     for(int i = 0; i < 8; i++) {
-        publisher.publish("TEST_PUB_HIGH",
+        publisher.publish<int>("TEST_PUB_HIGH",
                             str.c_str(),
                             PRIVATE,
                             1,
-                            priority_high_cb);
+                            priority_high_cb2, 1);
     }
-    REQUIRE(publisher.publish("TEST_PUB_HIGH",
+    REQUIRE(publisher.publish<int>("TEST_PUB_HIGH",
                         str.c_str(), 
                         PRIVATE,
                         2, 
-                        priority_high_cb ) == false);
+                        priority_high_cb2, 1) == false);
 
     // CANCELLED, run cleanup()
     high_cb_counter = 0;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -105,6 +105,8 @@ TEST_CASE("Test Background Publish") {
                         PRIVATE,
                         2, 
                         priority_high_cb ) == false);
+    REQUIRE(high_cb_counter == 1);
+    REQUIRE(status_returned == particle::Error::INVALID_ARGUMENT);
     
     // PASS, enough levels/queues
     REQUIRE(publisher.publish("TEST_PUB_HIGH",
@@ -121,7 +123,6 @@ TEST_CASE("Test Background Publish") {
     // burst process two messages at t = 1000
     publisher.processOnce();
     publisher.processOnce();
-    REQUIRE(high_cb_counter == 0);
     REQUIRE(low_cb_counter == 2);
     REQUIRE(status_returned == particle::Error::NONE);
 


### PR DESCRIPTION
Rather than rely on C-style `void *context` parameter for callbacks, in C++ context parameters can be bound using `std::bind` or lamdba captures to create callback function signatures free of generic pointers.

Templated convenience wrappers remain to allow any context type to be bound to a matching callback function.